### PR TITLE
zetcd: use etcd versions for tracking cver

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -51,7 +51,7 @@ func statTxn(txnresp *etcd.TxnResponse) (s Stat) {
 		s.Version = Ver(mtime.Kvs[0].Version - 1)
 	}
 	if len(cver.Kvs) != 0 {
-		s.Cversion = Ver(decodeInt64(cver.Kvs[0].Value))
+		s.Cversion = Ver(cver.Kvs[0].Version - 1)
 	}
 	if len(aver.Kvs) != 0 {
 		s.Aversion = Ver(decodeInt64(aver.Kvs[0].Value))


### PR DESCRIPTION
Heavy contention on /zk/cver keys from RMW accesses causes STM to
retry too often. Instead, blindly write to cver keys and use the
etcd version for the znode stats.

Fixes #9 

/cc @gyuho