### PR TITLE
Fix path generation for sequential paths (fixes Mesos leader election)

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -351,6 +351,19 @@ func TestCreateInvalidACL(t *testing.T) {
 	})
 }
 
+func TestCreateInvalidPath(t *testing.T) {
+	runTest(t, func(t *testing.T, c *zk.Conn) {
+		werr := zetcd.ErrUnknown
+		resp, err := c.Create("/.", []byte("x"), 0, nil)
+		if err == nil {
+			t.Fatalf("created with invalid path %v, wanted %v", resp, werr)
+		}
+		if err.Error() != werr.Error() {
+			t.Fatalf("got err %v, wanted %v", err, werr)
+		}
+	})
+}
+
 func runTest(t *testing.T, f func(*testing.T, *zk.Conn)) {
 	zkclus := newZKCluster(t)
 	defer zkclus.Close(t)

--- a/path.go
+++ b/path.go
@@ -14,12 +14,8 @@
 
 package zetcd
 
-import (
-	"path"
-)
-
 func mkPath(zkPath string) string {
-	p := path.Clean(zkPath)
+	p := zkPath
 	if p[0] != '/' {
 		p = "/" + p
 	}


### PR DESCRIPTION
Calling path.Clean when making paths squashes the trailing '/' which has significance for how Zookeeper handles the owning parent of FlagSequential key creation.

This notably broke mesos log_replica recovery, since the correct child nodes were not being implicitely created by the sequential paths it expects to be generated, and thus a subsequent watch on `/mesos/log_replicas/` would never yield any events (because the keys were being created at `/mesos/log_replicas0000000x`.

As part of this patch, `mkPath` is delegated as a pure ZK -> etcd conversion function, and the Zookeeper path validation is implemented at the relevant functions for ZooKeeper (`validatePath`) following the calls in `./src/java/main/org/apache/zookeeper/server/PrepRequestProcessor.java`

Resolves #5 
Closes #28 