### PR TITLE
zk, xchk: fix connection leaks

### DIFF
--- a/xchk/conn.go
+++ b/xchk/conn.go
@@ -142,6 +142,7 @@ func (c *conn) Close() {
 		close(ch)
 	}
 	c.oobRespPath = nil
+	c.zkc.Close()
 	c.mu.Unlock()
 	<-c.donec
 }

--- a/zk/session.go
+++ b/zk/session.go
@@ -44,6 +44,11 @@ func (s *session) ZXid() zetcd.ZXid { return 111111 }
 func (s *session) ConnReq() zetcd.ConnectRequest { return s.connReq }
 func (s *session) Backing() interface{}          { return s }
 
+func (s *session) Close() {
+	s.Conn.Close()
+	s.zkc.Close()
+}
+
 func newSession(servers []string, zka zetcd.AuthConn) (*session, error) {
 	defer zka.Close()
 	glog.V(6).Infof("newSession(%s)", servers)


### PR DESCRIPTION
* zk wasn't closing zookeeper bridge client in zk.session.Close()
* xchk wasn't closing connection in xchk.conn.Close()

Fixes #43 (I assume the leaks were in xchk mode since issue uses goofy port 2182; couldn't repro in regular mode)