### PR TITLE
zketcd: short and debug path encodings

### DIFF
--- a/path.go
+++ b/path.go
@@ -77,32 +77,10 @@ func validatePath(zkPath string) error {
 	return nil
 }
 
-func mkPath(zkPath string) string {
-	p := zkPath
-	if p[0] != '/' {
-		p = "/" + p
-	}
-	depth := 0
-	for i := 0; i < len(p); i++ {
-		if p[i] == '/' {
-			depth++
-		}
-	}
-	return string(append([]byte{byte(depth)}, []byte(p)...))
-}
-
-func incPath(zetcdPath string) string {
-	b := []byte(zetcdPath)
-	b[0]++
-	return string(b)
-}
-
 func getListPfx(p string) string {
-	pfx := "/zk/ver/"
 	if len(p) != 2 {
 		// /abc => 1 => listing dir needs search on p[0] = 2
-		searchP := string([]byte{p[0] + 1}) + p[1:]
-		return pfx + searchP + "/"
+		return mkPathMTime(incPath(p) + "/")
 	}
-	return pfx + p
+	return mkPathMTime(p)
 }

--- a/pool.go
+++ b/pool.go
@@ -143,7 +143,7 @@ func (sp *etcdSessionBackend) resume(sid Sid, pwd []byte) (etcd.LeaseID, error) 
 	return etcd.LeaseID(sid), nil
 }
 
-func lid2key(lid etcd.LeaseID) string { return fmt.Sprintf("/zk/ses/%x", lid) }
+func lid2key(lid etcd.LeaseID) string { return mkPathSession(uint64(lid)) }
 
 type aesSessionBackend struct {
 	c   *etcd.Client

--- a/stat.go
+++ b/stat.go
@@ -20,12 +20,12 @@ import (
 
 func statGets(p string) []etcd.Op {
 	return []etcd.Op{
-		etcd.OpGet("/zk/ctime/"+p, etcd.WithSerializable()),
-		etcd.OpGet("/zk/mtime/"+p, etcd.WithSerializable(),
+		etcd.OpGet(mkPathCTime(p), etcd.WithSerializable()),
+		etcd.OpGet(mkPathMTime(p), etcd.WithSerializable(),
 			etcd.WithSort(etcd.SortByModRevision, etcd.SortDescend)),
-		etcd.OpGet("/zk/key/"+p, etcd.WithSerializable()),
-		etcd.OpGet("/zk/cver/"+p, etcd.WithSerializable()),
-		etcd.OpGet("/zk/aver/"+p, etcd.WithSerializable()),
+		etcd.OpGet(mkPathKey(p), etcd.WithSerializable()),
+		etcd.OpGet(mkPathCVer(p), etcd.WithSerializable()),
+		etcd.OpGet(mkPathACL(p), etcd.WithSerializable(), etcd.WithKeysOnly()),
 		// to compute num children
 		etcd.OpGet(getListPfx(p), etcd.WithSerializable(), etcd.WithPrefix()),
 	}
@@ -55,7 +55,7 @@ func statTxn(txnresp *etcd.TxnResponse) (s Stat) {
 		s.Pzxid = rev2zxid(cver.Kvs[0].ModRevision)
 	}
 	if len(aver.Kvs) != 0 {
-		s.Aversion = Ver(decodeInt64(aver.Kvs[0].Value))
+		s.Aversion = Ver(aver.Kvs[0].Version - 1)
 	}
 	if len(node.Kvs) != 0 {
 		s.EphemeralOwner = Sid(node.Kvs[0].Lease)

--- a/watches.go
+++ b/watches.go
@@ -113,7 +113,7 @@ func (ws *watches) Watch(rev ZXid, xid Xid, path string, evtype EventType, cb fu
 		fallthrough
 	// use rev+1 watch begins AFTER the requested zxid
 	case EventNodeDeleted:
-		wch = ws.c.Watch(ctx, "/zk/key/"+path, etcd.WithRev(int64(rev+1)))
+		wch = ws.c.Watch(ctx, mkPathKey(path), etcd.WithRev(int64(rev+1)))
 	case EventNodeChildrenChanged:
 		wch = ws.c.Watch(
 			ctx,

--- a/zketcd_path.go
+++ b/zketcd_path.go
@@ -1,0 +1,51 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !path_debug,!path_old
+
+package zetcd
+
+import "fmt"
+
+func mkPath(zkPath string) string {
+	p := zkPath
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	depth := 0
+	for i := 0; i < len(p); i++ {
+		if p[i] == '/' {
+			depth++
+		}
+	}
+	return string(append([]byte{byte(depth)}, []byte(p)...))
+}
+
+func incPath(zetcdPath string) string {
+	b := []byte(zetcdPath)
+	b[0]++
+	return string(b)
+}
+
+// non-human readable metadata paths
+
+func mkPathErrNode() string           { return "/zk/e" }
+func mkPathKey(p string) string       { return "/zk/\x01" + p }
+func mkPathVer(p string) string       { return "/zk/\x02" + p }
+func mkPathCVer(p string) string      { return "/zk/\x03" + p }
+func mkPathCTime(p string) string     { return "/zk/\x04" + p }
+func mkPathMTime(p string) string     { return "/zk/\x05" + p }
+func mkPathACL(p string) string       { return "/zk/\x06" + p }
+func mkPathCount(p string) string     { return "/zk/\x07" + p }
+func mkPathSession(lid uint64) string { return fmt.Sprintf("/zk/\x08%x", lid) }

--- a/zketcd_path_debug.go
+++ b/zketcd_path_debug.go
@@ -1,0 +1,50 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build path_debug
+
+package zetcd
+
+import "fmt"
+
+func mkPath(zkPath string) string {
+	p := zkPath
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	depth := 0
+	for i := 0; i < len(p); i++ {
+		if p[i] == '/' {
+			depth++
+		}
+	}
+	return fmt.Sprintf("%03d%s", depth, p)
+}
+
+func incPath(p string) string {
+	v := 0
+	fmt.Sscanf(p[:3], "%d", &v)
+	return fmt.Sprintf("%03d", v+1) + p[3:]
+}
+
+func mkPathErrNode() string       { return "/zk/err-node" }
+func mkPathKey(p string) string   { return "/zk/key/" + p }
+func mkPathVer(p string) string   { return "/zk/ver/" + p }
+func mkPathCVer(p string) string  { return "/zk/cver/" + p }
+func mkPathCTime(p string) string { return "/zk/ctime/" + p }
+func mkPathMTime(p string) string { return "/zk/mtime/" + p }
+func mkPathACL(p string) string   { return "/zk/acl/" + p }
+func mkPathCount(p string) string { return "/zk/count/" + p }
+
+func mkPathSession(lid uint64) string { return fmt.Sprintf("/zk/session/%x", lid) }

--- a/zketcd_path_old.go
+++ b/zketcd_path_old.go
@@ -1,0 +1,50 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !path_debug,path_old
+
+package zetcd
+
+import "fmt"
+
+func mkPath(zkPath string) string {
+	p := zkPath
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	depth := 0
+	for i := 0; i < len(p); i++ {
+		if p[i] == '/' {
+			depth++
+		}
+	}
+	return string(append([]byte{byte(depth)}, []byte(p)...))
+}
+
+func incPath(zetcdPath string) string {
+	b := []byte(zetcdPath)
+	b[0]++
+	return string(b)
+}
+
+func mkPathErrNode() string       { return "/zk/err-node" }
+func mkPathKey(p string) string   { return "/zk/key/" + p }
+func mkPathVer(p string) string   { return "/zk/ver/" + p }
+func mkPathCVer(p string) string  { return "/zk/cver/" + p }
+func mkPathCTime(p string) string { return "/zk/ctime/" + p }
+func mkPathMTime(p string) string { return "/zk/mtime/" + p }
+func mkPathACL(p string) string   { return "/zk/acl/" + p }
+func mkPathCount(p string) string { return "/zk/count/" + p }
+
+func mkPathSession(lid uint64) string { return fmt.Sprintf("/zk/ses/%x", lid) }


### PR DESCRIPTION
Adds a human-readable path tag "path_debug" for building with easier
to read paths. Default paths are changed to be shorter, with classic
paths supported with "path_old".

Also gets rid of 'aver' key since the version can be inferred from the
ACL key itself.

Fixes #23