### PR TITLE
zketcd: increment sequential counter for every child created

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -171,6 +171,7 @@ func TestCreateSequential(t *testing.T) {
 		}
 		// Test node creation with a trailing / character. This should produce
 		// a subdirectory, with the parent node acting as the counter.
+		// This will create node#2 in /abc/ (but not sequentially named)
 		if _, err := c.Create("/abc/defg", []byte("x"), 0, acl); err != nil {
 			t.Fatal(err)
 		}
@@ -189,11 +190,12 @@ func TestCreateSequential(t *testing.T) {
 		}
 		// Check that creating /abc/def increments to 3 (i.e. the above did not
 		// get stored under the parent node somehow.
+		// This will create node#3 in /abc/
 		s, err = c.Create("/abc/def", []byte("x"), zk.FlagSequence, acl)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if s != "/abc/def0000000002" {
+		if s != "/abc/def0000000003" {
 			t.Fatalf("got %s, expected /abc/def%010d", s, 2)
 		}
 	})

--- a/zketcd.go
+++ b/zketcd.go
@@ -94,17 +94,18 @@ func (z *zkEtcd) mkCreateTxnOp(op *CreateRequest) opBundle {
 		}
 
 		p, respPath = mkPath(op.Path), op.Path
+
+		count := int32(decodeInt64([]byte(s.Get(mkPathCount(pp)))))
 		if op.Flags&FlagSequence != 0 {
-			count := int32(decodeInt64([]byte(s.Get(mkPathCount(pp)))))
 			// force as int32 to get integer overflow as per zk docs
 			cstr := fmt.Sprintf("%010d", count)
 			p += cstr
 			respPath += cstr
-			count++
-			s.Put(mkPathCount(pp), encodeInt64(int64(count)))
 		} else if len(s.Get(mkPathCTime(p))) != 0 {
 			return ErrNodeExists
 		}
+		count++
+		s.Put(mkPathCount(pp), encodeInt64(int64(count)))
 
 		t := encodeTime()
 


### PR DESCRIPTION
Fixes the test xchk error:
```
--- FAIL: TestCreateSequential (2.99s)
        cluster_xchk.go:29: xchk failed (path mismatch)
                candidate: &{Path:/abc/def0000000002}
                oracle: &{Path:/abc/def0000000003}
                
        integration_test.go:197: got /abc/def0000000003, expected /abc/def0000000002
FAIL
```