### PR TITLE
match zk errors for accessing invalid paths

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -400,13 +400,38 @@ func TestCreateInvalidACL(t *testing.T) {
 
 func TestCreateInvalidPath(t *testing.T) {
 	runTest(t, func(t *testing.T, c *zk.Conn) {
-		werr := zetcd.ErrUnknown
+		werr := zetcd.ErrInvalidACL
 		resp, err := c.Create("/.", []byte("x"), 0, nil)
 		if err == nil {
-			t.Fatalf("created with invalid path %v, wanted %v", resp, werr)
+			t.Errorf("created with invalid path %v, wanted %v", resp, werr)
+		} else if err.Error() != werr.Error() {
+			t.Errorf("got err %v, wanted %v", err, werr)
 		}
-		if err.Error() != werr.Error() {
-			t.Fatalf("got err %v, wanted %v", err, werr)
+
+		// this is ErrBadArguments under the hood but the zk library
+		// doesn't recognize it so it goes to ErrUnknown
+		werr = zetcd.ErrUnknown
+		sresp, err := c.Set("/.", []byte("x"), -1)
+		if err == nil {
+			t.Errorf("created with invalid path %v, wanted %v", sresp, werr)
+		} else if err.Error() != werr.Error() {
+			t.Errorf("got err %v, wanted %v", err, werr)
+		}
+
+		werr = zetcd.ErrNoNode
+		err = c.Delete("/.", -1)
+		if err == nil {
+			t.Errorf("created with invalid path %v, wanted %v", sresp, werr)
+		} else if err.Error() != werr.Error() {
+			t.Errorf("got err %v, wanted %v", err, werr)
+		}
+
+		werr = zetcd.ErrNoNode
+		_, _, err = c.Get("/.")
+		if err == nil {
+			t.Errorf("got err %v, wanted %v", err, werr)
+		} else if err.Error() != werr.Error() {
+			t.Errorf("got err %v, wanted %v", err, werr)
 		}
 	})
 }

--- a/zketcd.go
+++ b/zketcd.go
@@ -64,7 +64,7 @@ func (z *zkEtcd) mkCreateTxnOp(op *CreateRequest) opBundle {
 		zkPath = fmt.Sprintf("%s1", zkPath)
 	}
 	if err := validatePath(zkPath); err != nil {
-		return mkBadArgumentsTxnOp()
+		return mkErrTxnOp(ErrInvalidACL)
 	}
 
 	opts := []etcd.OpOption{}
@@ -334,7 +334,7 @@ func (z *zkEtcd) SetData(xid Xid, op *SetDataRequest) ZKResponse {
 
 func (z *zkEtcd) mkSetDataTxnOp(op *SetDataRequest) opBundle {
 	if err := validatePath(op.Path); err != nil {
-		return mkBadArgumentsTxnOp()
+		return mkErrTxnOp(ErrBadArguments)
 	}
 
 	p := mkPath(op.Path)
@@ -534,7 +534,7 @@ func (z *zkEtcd) Multi(xid Xid, mreq *MultiRequest) ZKResponse {
 
 func (z *zkEtcd) mkCheckVersionPathTxnOp(op *CheckVersionRequest) opBundle {
 	if err := validatePath(op.Path); err != nil {
-		return mkBadArgumentsTxnOp()
+		return mkErrTxnOp(ErrBadArguments)
 	}
 	p := mkPath(op.Path)
 	apply := func(s v3sync.STM) (err error) {
@@ -733,11 +733,11 @@ func updateErrRev(s v3sync.STM) {
 	}
 }
 
-func mkBadArgumentsTxnOp() opBundle {
+func mkErrTxnOp(err error) opBundle {
 	return opBundle{
 		apply: func(s v3sync.STM) error {
 			updateErrRev(s)
-			return ErrBadArguments
+			return err
 		},
 	}
 }


### PR DESCRIPTION
via xchk:
```
--- FAIL: TestCreateInvalidPath (3.45s)
cluster_xchk.go:29: xchk failed (err mismatch)
        candidate: &{Xid:1 Zxid:2 Err:-8}
        oracle: &{Xid:1 Zxid:2 Err:-114}

integration_test.go:409: got err zk: invalid ACL specified, wanted zk: unknown error
FAIL
```