### PR TITLE
scripts: use go1.8.3 and build docker image with cmd/zetcd

### DIFF
--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -5,7 +5,7 @@ docker run \
     -e VERSION=$VERSION \
     -v $PWD:/go/src/github.com/coreos/zetcd:ro \
     -w /go/src/github.com/coreos/zetcd \
-    golang:1.8.0-alpine \
+    golang:1.8.3-alpine \
     /bin/sh -x -c scripts/release-binary
 
 docker cp $( cat cid ):/go/bin/zetcd bin/zetcd-release

--- a/scripts/release-binary
+++ b/scripts/release-binary
@@ -4,4 +4,4 @@ REPO_PATH=github.com/coreos/zetcd
 
 go build -o $GOPATH/bin/zetcd -v \
   -ldflags "-w -X $REPO_PATH/version.Version=$VERSION" \
-  $REPO_PATH
+  $REPO_PATH/cmd/zetcd


### PR DESCRIPTION
Building using $REPO would build an archive that doesn't run
in the docker image.