### PR TITLE
Use last Value for get instead of third Value

### DIFF
--- a/zketcd.go
+++ b/zketcd.go
@@ -324,7 +324,17 @@ func (z *zkEtcd) GetData(xid Xid, op *GetDataRequest) ZKResponse {
 		}
 		z.s.Watch(zxid, xid, p, EventNodeDataChanged, f)
 	}
-	datResp.Data = []byte(txnresp.Responses[2].GetResponseRange().Kvs[0].Value)
+
+	value := []byte{}
+	for idx, element := range txnresp.Responses {
+		kvs := element.GetResponseRange().Kvs
+		glog.V(7).Infof("GetData(%v) = (zxid=%v, idx=%v, resps=%+v)", xid, zxid, idx,
+			len(kvs))
+		if (len(kvs) > 0) && (len(kvs[0].Value) > 0) {
+			value = []byte(kvs[0].Value)
+		}
+	}
+	datResp.Data = value
 
 	glog.V(7).Infof("GetData(%v) = (zxid=%v, resp=%+v)", xid, zxid, *datResp)
 	return mkZKResp(xid, zxid, datResp)


### PR DESCRIPTION
Sometimes (such as when doing a get on /), the server's response won't
have any Kvs in the second response. This causes zetcd to crash when a
client does a get on /. I'm not certain this change is valid, but it
does prevent the crash. It also gives some rather arbitrary looking data
for the node's value, probably because it's using an arbitrary response
instead of the hard-coded second response. Maybe we need to always use
Responses[2], but if it has no Kvs, use an empty byte array instead of
crashing?

If desired, I can make that change. I just don't want zetcd to crash quite so easily.