### PR TITLE
preserve ephemeral owner and permit directory deletion after losing ephemeral children

### DIFF
--- a/zketcd.go
+++ b/zketcd.go
@@ -213,13 +213,15 @@ func (z *zkEtcd) mkDeleteTxnOp(op *DeleteRequest) opBundle {
 			}
 		}
 
-		crev := s.Rev(mkPathCVer(p))
+		// Force CVer into read-set to catch any conflicting update
+		// which would invalidate emptiness check.
+		s.Rev(mkPathCVer(p))
+		// Check if directory has any children.
 		gresp, gerr := z.c.Get(z.c.Ctx(), getListPfx(p),
 			// TODO: monotonic revisions from serializable
 			// etcd.WithSerializable(),
 			etcd.WithPrefix(),
 			etcd.WithCountOnly(),
-			etcd.WithRev(crev),
 			etcd.WithLimit(1))
 		if gerr != nil {
 			return gerr

--- a/zketcd.go
+++ b/zketcd.go
@@ -360,9 +360,9 @@ func (z *zkEtcd) mkSetDataTxnOp(op *SetDataRequest) opBundle {
 			return ErrBadVersion
 
 		}
-		s.Put(mkPathKey(p), string(op.Data))
-		s.Put(mkPathVer(p), string(encodeInt64(int64(currentVersion+1))))
-		s.Put(mkPathMTime(p), encodeTime())
+		s.Put(mkPathKey(p), string(op.Data), etcd.WithIgnoreLease())
+		s.Put(mkPathVer(p), string(encodeInt64(int64(currentVersion+1))), etcd.WithIgnoreLease())
+		s.Put(mkPathMTime(p), encodeTime(), etcd.WithIgnoreLease())
 		return nil
 	}
 


### PR DESCRIPTION
/cc @tsuraan

This is a partial fix. etcd will probably need an API extension to accurately cross-check against zookeeper.

Fixes #88 